### PR TITLE
Fix 32-bit compilation

### DIFF
--- a/src/wmi_wrapper.cpp
+++ b/src/wmi_wrapper.cpp
@@ -99,7 +99,7 @@ namespace wmi_wrapper
         IWbemClassObject *class_object)
     {
         HRESULT hres = ERROR_SUCCESS;
-        for (int i = 0; i < properties.size(); ++i)
+        for (size_t i = 0; i < properties.size(); ++i)
         {
             std::wstring value = GetPropertyValue(properties[i], class_object);
             (*results).push_back(make_pair(properties[i], std::wstring(value)));
@@ -362,10 +362,10 @@ namespace wmi_wrapper
         Napi::Object return_values = Napi::Object::New(env);
 
         size_t results_length = results.size();
-        for (int i = 0; i < results_length; ++i)
+        for (size_t i = 0; i < results_length; ++i)
         {
             Napi::Object return_obj = Napi::Object::New(env);
-            for (int j = 0; j < results[i].size(); ++j)
+            for (size_t j = 0; j < results[i].size(); ++j)
             {
                 std::wstring wst_key = results[i][j].first;
                 std::wstring wst_value = results[i][j].second;


### PR DESCRIPTION
Without this node-gyp produces the following error when compiling:

```
C:\wmi-native-module-main\src\wmi_wrapper.cpp(102,27): error C2220: the following warning is treated as an error [C:\wmi-native-module-main\build\wmi_native_module.vcxproj]
C:\wmi-native-module-main\src\wmi_wrapper.cpp(102,27): warning C4018: '<': signed/unsigned mismatch [C:\wmi-native-module-main\build\wmi_native_module.vcxproj]
C:\wmi-native-module-main\src\wmi_wrapper.cpp(365,27): warning C4018: '<': signed/unsigned mismatch [C:\wmi-native-module-main\build\wmi_native_module.vcxproj]
C:\wmi-native-module-main\src\wmi_wrapper.cpp(368,31): warning C4018: '<': signed/unsigned mismatch [C:\wmi-native-module-main\build\wmi_native_module.vcxproj]
```