### PR TITLE
Handle alternate COM concurrency mode

### DIFF
--- a/src/wmi_wrapper.cpp
+++ b/src/wmi_wrapper.cpp
@@ -223,6 +223,11 @@ namespace wmi_wrapper
         // Initialize COM.
         hres = CoInitializeEx(0, COINIT_MULTITHREADED);
         {
+	    if (FAILED(hres) && hres == RPC_E_CHANGED_MODE)
+	    {
+		// Was already initialized in a different mode, switch
+		hres = CoInitializeEx(0, COINIT_APARTMENTTHREADED);
+	    }
             if (FAILED(hres))
             {
                 // Failed to initialize COM library


### PR DESCRIPTION
If the module is used in a program which has already initialized COM in Apartement concurrency mode (for instance within an Electron project), CoInitializeEx will return error RPC_E_CHANGED_MODE. In that case, try initializing again in that mode.